### PR TITLE
Fix fallback line number alignment

### DIFF
--- a/src/litprinter/traceback.py
+++ b/src/litprinter/traceback.py
@@ -888,8 +888,12 @@ class PrettyTraceback:
         if not lines_available:
             if frame_info.line:
                 # If we at least have the error line, show it
+                # Format the line number first to ensure padding is applied
+                # before adding ANSI styles so alignment isn't affected
+                line_num_str = f"{frame_info.lineno:>{4}}"
+                styled_line_num = Styles.LineNo(line_num_str)
                 code_context_lines.append(
-                    f"  {Styles.ErrorMarker(ERROR_LINE_MARKER)} {Styles.LineNo(str(frame_info.lineno)):>{4}} {LINE_SEPARATOR} {Styles.Bold(frame_info.line)}"
+                    f"  {Styles.ErrorMarker(ERROR_LINE_MARKER)} {styled_line_num} {LINE_SEPARATOR} {Styles.Bold(frame_info.line)}"
                 )
             else:
                 # Otherwise show a message

--- a/src/litprinter/traceback.py
+++ b/src/litprinter/traceback.py
@@ -890,7 +890,7 @@ class PrettyTraceback:
                 # If we at least have the error line, show it
                 # Format the line number first to ensure padding is applied
                 # before adding ANSI styles so alignment isn't affected
-                line_num_str = f"{frame_info.lineno:>{4}}"
+                line_num_str = f"{frame_info.lineno:>4}"
                 styled_line_num = Styles.LineNo(line_num_str)
                 code_context_lines.append(
                     f"  {Styles.ErrorMarker(ERROR_LINE_MARKER)} {styled_line_num} {LINE_SEPARATOR} {Styles.Bold(frame_info.line)}"


### PR DESCRIPTION
## Summary
- fix line number formatting in traceback fallback case

## Testing
- `python -m py_compile src/litprinter/traceback.py`
- `pytest -q` *(fails: command not found)*